### PR TITLE
Add crossbuild information to promu config

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -10,6 +10,13 @@ build:
         - name: pushprox-proxy
           path: ./cmd/proxy
     flags: -mod=vendor -a -tags netgo
+crossbuild:
+  platforms:
+    - linux/amd64
+    - linux/armv7
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
 tarball:
     files:
         - LICENSE


### PR DESCRIPTION
This is required in order to build the docker-container (with `make
common-docker`) and the architectures match those defined in the
Makefile.