### PR TITLE
Added basic auth for proxy and /clients endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,24 +54,21 @@ file\_sd\_configs can read and then then relabel as needed.
 
 ![Sequence diagram](./docs/sequence.svg)
 
-Clients perform scrapes in a network environment that's not directly accessible by Prometheus. 
+Clients perform scrapes in a network environment that's not directly accessible by Prometheus.
 The Proxy is accessible by both the Clients and Prometheus.
 Each client is identified by its fqdn.
 
 For example, the following sequence is performed when Prometheus scrapes target `fqdn-x` via PushProx.
-First, a Client polls the Proxy for scrape requests, and includes its fqdn in the poll (1). 
+First, a Client polls the Proxy for scrape requests, and includes its fqdn in the poll (1).
 The Proxy does not respond yet.
 Next, Prometheus tries to scrape the target with hostname `fqdn-x` via the Proxy (2).
 Using the fqdn received in (1), the Proxy now routes the scrape to the correct Client: the scrape request is in the response body of the poll (3).
-This scrape request is executed by the client (4), the response containing metrics (5) is posted to the Proxy (6). 
+This scrape request is executed by the client (4), the response containing metrics (5) is posted to the Proxy (6).
 On its turn, the Proxy returns this to Prometheus (7) as a reponse to the initial scrape of (2).
 
 PushProx passes all HTTP headers transparently, features like compression and accept encoding are up to the scraping Prometheus server.
 
 ## Security
 
-There is no authentication or authorisation included, a reverse proxy can be
-put in front though to add these.
-
-Running the client allows those with access to the proxy or the client to access
-all network services on the machine hosting the client.
+You can enable basic auth by providing `--web.auth.username` and `--web.auth.password` to protect proxy requests and `/clients` endpoint.
+Also there is possibility to disable `/clients` listing with `--web.disable-clients` to prevent discovery of clients if that's not needed for your use case.

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -35,11 +35,11 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
+	"github.com/prometheus-community/pushprox/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
-	"github.com/prometheus-community/pushprox/util"
 )
 
 var (

--- a/cmd/proxy/coordinator.go
+++ b/cmd/proxy/coordinator.go
@@ -25,9 +25,9 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/google/uuid"
+	"github.com/prometheus-community/pushprox/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus-community/pushprox/util"
 )
 
 var (

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -42,6 +43,8 @@ const (
 )
 
 var (
+	authUser             = kingpin.Flag("web.auth.username", "Basic auth username").Default("").String()
+	authPassword         = kingpin.Flag("web.auth.password", "Basic auth password").Default("").String()
 	listenAddress        = kingpin.Flag("web.listen-address", "Address to listen on for proxy and client requests.").Default(":8080").String()
 	maxScrapeTimeout     = kingpin.Flag("scrape.max-timeout", "Any scrape with a timeout higher than this will have to be clamped to this.").Default("5m").Duration()
 	defaultScrapeTimeout = kingpin.Flag("scrape.default-timeout", "If a scrape lacks a timeout, use this value.").Default("15s").Duration()
@@ -92,6 +95,25 @@ type httpHandler struct {
 	proxy       http.Handler
 }
 
+func basicAuth(handler http.HandlerFunc) http.HandlerFunc {
+	if *authUser == "" && *authPassword == "" {
+		return handler
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		user, pass, ok := r.BasicAuth()
+
+		if !ok || subtle.ConstantTimeCompare([]byte(user), []byte(*authUser)) != 1 || subtle.ConstantTimeCompare([]byte(pass), []byte(*authPassword)) != 1 {
+			w.Header().Set("WWW-Authenticate", `Basic realm="Authentication required"`)
+			w.WriteHeader(401)
+			w.Write([]byte("Unauthorised.\n"))
+			return
+		}
+
+		handler(w, r)
+	}
+}
+
 func newHTTPHandler(logger log.Logger, coordinator *Coordinator, mux *http.ServeMux) *httpHandler {
 	h := &httpHandler{logger: logger, coordinator: coordinator, mux: mux}
 
@@ -99,7 +121,7 @@ func newHTTPHandler(logger log.Logger, coordinator *Coordinator, mux *http.Serve
 	handlers := map[string]http.HandlerFunc{
 		"/push":    h.handlePush,
 		"/poll":    h.handlePoll,
-		"/clients": h.handleListClients,
+		"/clients": basicAuth(h.handleListClients),
 		"/metrics": promhttp.Handler().ServeHTTP,
 	}
 	for path, handlerFunc := range handlers {
@@ -118,7 +140,7 @@ func newHTTPHandler(logger log.Logger, coordinator *Coordinator, mux *http.Serve
 	}
 
 	// proxy handler
-	h.proxy = promhttp.InstrumentHandlerCounter(httpProxyCounter, http.HandlerFunc(h.handleProxy))
+	h.proxy = promhttp.InstrumentHandlerCounter(httpProxyCounter, http.HandlerFunc(basicAuth(h.handleProxy)))
 
 	return h
 }


### PR DESCRIPTION
This PR adds possibility to enable basic auth for proxy requests and `/clients` endpoint.
Also it adds possibility to disable `/clients` endpoint completely.

I do not see any benefit from securing other endpoints as those should not have any possibility to penetrate network.
I know that it was mentioned already that any security features should be added by other means for prometheus projects, but as the whole purpose of this project is to overcome firewall limitations this addition would be very welcome.