### PR TITLE
Binary size optimizations

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -9,7 +9,8 @@ build:
           path: ./cmd/client
         - name: pushprox-proxy
           path: ./cmd/proxy
-    flags: -a -tags netgo
+    flags: -trimpath -a -tags netgo
+    ldflags: -s -w -X main.Version=={{.Version}}
 tarball:
     files:
         - LICENSE


### PR DESCRIPTION
Though sharing my tunes in build phase for smaller binary size (remove symbols and dwarfs)

before
```
-rwxr-xr-x    1 root     root      13455659 Feb  4 13:46 pushprox-client
-rwxr-xr-x    1 root     root      12952375 Feb  4 13:46 pushprox-proxy
```

after
```
-rwxr-xr-x    1 root     root       9482240 Feb  4 13:46 pushprox-client
-rwxr-xr-x    1 root     root       9121792 Feb  4 13:47 pushprox-proxy

```