### PR TITLE
Fix /clients endpoint to return application/json Content-Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master / unreleased
 
+* [FIX] /clients endpoint return application/json as Content-Type
+
 ## 0.1.0 / 2019-07-29
 
 * [CHANGE] Initial release

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -162,6 +162,7 @@ func (h *httpHandler) handleListClients(w http.ResponseWriter, r *http.Request) 
 	for _, k := range known {
 		targets = append(targets, &targetGroup{Targets: []string{k}})
 	}
+	w.Header().Set("Content-Type", "application/json")
 	//nolint:errcheck // https://github.com/prometheus-community/PushProx/issues/111
 	json.NewEncoder(w).Encode(targets)
 	level.Info(h.logger).Log("msg", "Responded to /clients", "client_count", len(known))


### PR DESCRIPTION
Due to the Content-Type returned by the `/clients` endpoint (`text/plain` instead of `application/json`) it’s not possible to hook it directly to Prometheus through its `http_sd_config`.

This PR fixes that.