### PR TITLE
Check status code when polling finished

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -200,6 +200,11 @@ func (c *Coordinator) doPoll(client *http.Client) error {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		level.Warn(c.logger).Log("msg", "Unexpected response", "statusCode", resp.StatusCode)
+		return fmt.Errorf("unexpected response status=%d", resp.StatusCode)
+	}
+
 	request, err := http.ReadRequest(bufio.NewReader(resp.Body))
 	if err != nil {
 		level.Error(c.logger).Log("msg", "Error reading request:", "err", err)


### PR DESCRIPTION
Reverse proxies(e.g. nginx / AWS ALB ) replies with `504 Gateway Tiemout` response when idle timeout elapsed.

Default value of idle timeouts for [AWS ALB](https://aws.amazon.com/premiumsupport/knowledge-center/504-error-alb/) / [nginx](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout)  are 60 seconds.

When pushprox-proxy has not received any scrape requests pushprox-client receives `504` reponse  after idle timeout elapsed.

So, I've added checking http response status code before reading the response body.

Fix. https://github.com/prometheus-community/PushProx/issues/77 https://github.com/prometheus-community/PushProx/issues/118