### PR TITLE
Fix up deprecated function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 version: 2.1
 orbs:
-  prometheus: prometheus/prometheus@0.16.0
+  prometheus: prometheus/prometheus@0.17.1
 executors:
   golang:
     docker:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,6 +25,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'
       - name: Lint
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.45.2
+          version: v1.51.2

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -254,8 +254,6 @@ func main() {
 
 		// Setup HTTPS client
 		tlsConfig.Certificates = []tls.Certificate{cert}
-
-		tlsConfig.BuildNameToCertificate()
 	}
 
 	if *caCertFile != "" {


### PR DESCRIPTION
BuildNameToCertificate was deprecated in Go 1.14.
* Deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates.
* Bump golangci-lint.