### PR TITLE
Fix long-poll hang on ip change using KeepAliveConfig (Go 1.23)

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -279,8 +279,13 @@ func main() {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
+			Timeout: 30 * time.Second,
+			KeepAliveConfig: net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     30 * time.Second,
+				Interval: 5 * time.Second,
+				Count:    3,
+			},
 			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          100,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus-community/pushprox
 
-go 1.22
+go 1.23
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0


### PR DESCRIPTION

This PR fixes issue (https://github.com/prometheus-community/PushProx/issues/205) by replacing the old `KeepAlive` config with the new `KeepAliveConfig` (introduced in Go 1.23), allowing more control over TCP keepalive behavior.

* Sets a shorter keepalive: `Idle=30s`, `Interval=5s`, `Count=3` → total timeout 40s instead of the old 4m 30s
* Bumps Go version from 1.22 to 1.23.

This change is to reduce the hang caused by the default TCP keepalive behavior when the client’s IP changes or connection gets interrupted.